### PR TITLE
[#324] Change ICTRP URL to get non-JS version of pages

### DIFF
--- a/collectors/ictrp/spider.py
+++ b/collectors/ictrp/spider.py
@@ -38,6 +38,7 @@ class Spider(CrawlSpider):
         self.rules = [
             Rule(LinkExtractor(
                 allow=r'trialsearch/Trial\d+\.aspx\?trialid=.+',
+                process_value=lambda value: value.replace('Trial3', 'Trial2'),
             ), callback=parse_record),
             Rule(LinkExtractor(
                 allow=r'trialsearch/crawl/crawl\d+\.aspx',


### PR DESCRIPTION
As title says, I just did a simple `replace` to get **Trial2** instead of **Trial3** (kudos @roll for the hint)

upd.
added fixes https://github.com/opentrials/opentrials/issues/324 to merge issue and PR on waffle
