### PR TITLE
[#678] Fix CrawlerProcess collectors and some minor adjustements to Sentry

### DIFF
--- a/collectors/actrn/collector.py
+++ b/collectors/actrn/collector.py
@@ -11,6 +11,6 @@ from .spider import Spider
 # Module API
 
 def collect(conf, conn, date_from=None, date_to=None):
-    process = CrawlerProcess(conf)
+    process = CrawlerProcess(conf['SCRAPY_SETTINGS'])
     process.crawl(Spider, conn=conn, date_from=date_from, date_to=date_to)
     process.start()

--- a/collectors/base/cli.py
+++ b/collectors/base/cli.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 import sys
 import dataset
 import logging
-from importlib import import_module
+import importlib
 from . import config
 from . import helpers
 logger = logging.getLogger(__name__)
@@ -25,7 +25,7 @@ def cli(argv):
     }
 
     # Get and call collector
-    collect = import_module('collectors.%s' % argv[1]).collect
+    collect = importlib.import_module('collectors.%s' % argv[1]).collect
     collect(conf, conn, *argv[2:])
 
 

--- a/collectors/base/config.py
+++ b/collectors/base/config.py
@@ -18,40 +18,34 @@ ENV = os.environ.get('PYTHON_ENV', 'development')
 if os.environ.get('CI'):
     ENV = 'testing'
 
-SENTRY = raven.Client(os.environ.get('SENTRY_DSN'))
-
-# Spiders
-
-SPIDER_MODULES = [
-    'collectors.actrn.spider',
-    'collectors.euctr.spider',
-    'collectors.gsk.spider',
-    'collectors.ictrp.spider',
-    'collectors.isrctn.spider',
-    'collectors.jprn.spider',
-    'collectors.pfizer.spider',
-    'collectors.pubmed.spider',
-    'collectors.takeda.spider',
-]
-
-# Network
-
-DOWNLOAD_DELAY = float(os.getenv('DOWNLOAD_DELAY', 1))
-AUTOTHROTTLE_ENABLED = True
-
-# Pipelines
-
 if ENV == 'testing':
     WAREHOUSE_URL = os.environ['TEST_WAREHOUSE_URL']
 else:
     WAREHOUSE_URL = os.environ['WAREHOUSE_URL']
 
-ITEM_PIPELINES = {
-    'collectors.base.pipelines.Warehouse': 100,
+# Scrapy
+
+SCRAPY_SETTINGS = {
+    'SPIDER_MODULES': [
+        'collectors.actrn.spider',
+        'collectors.euctr.spider',
+        'collectors.gsk.spider',
+        'collectors.ictrp.spider',
+        'collectors.isrctn.spider',
+        'collectors.jprn.spider',
+        'collectors.pfizer.spider',
+        'collectors.pubmed.spider',
+        'collectors.takeda.spider',
+    ],
+    'DOWNLOAD_DELAY': float(os.getenv('DOWNLOAD_DELAY', 1)),
+    'AUTOTHROTTLE_ENABLED': True,
+    'ITEM_PIPELINES': {
+        'collectors.base.pipelines.Warehouse': 100,
+    },
 }
 
-# Logging
 
+# Logging
 
 def setup_syslog_handler():
     if os.environ.get('LOGGING_URL', None):
@@ -61,6 +55,9 @@ def setup_syslog_handler():
         handler = logging.handlers.SysLogHandler()
     return handler
 
+
+SENTRY_DSN = os.environ.get('SENTRY_DSN')
+SENTRY = raven.Client(SENTRY_DSN)
 
 LOGGING_CONFIG = {
     'version': 1,
@@ -81,6 +78,11 @@ LOGGING_CONFIG = {
             '()': setup_syslog_handler,
             'level': 'INFO',
             'formatter': 'default',
+        },
+        'sentry': {
+            'level': 'ERROR',
+            'class': 'raven.handlers.logging.SentryHandler',
+            'dsn': SENTRY_DSN,
         },
     },
     'root': {

--- a/collectors/euctr/collector.py
+++ b/collectors/euctr/collector.py
@@ -11,6 +11,6 @@ from .spider import Spider
 # Module API
 
 def collect(conf, conn, date_from=None, date_to=None):
-    process = CrawlerProcess(conf)
+    process = CrawlerProcess(conf['SCRAPY_SETTINGS'])
     process.crawl(Spider, conn=conn, date_from=date_from, date_to=date_to)
     process.start()

--- a/collectors/fda_dap/collector.py
+++ b/collectors/fda_dap/collector.py
@@ -11,6 +11,6 @@ from .spider import Spider
 # Module API
 
 def collect(conf, conn):
-    process = CrawlerProcess(conf)
+    process = CrawlerProcess(conf['SCRAPY_SETTINGS'])
     process.crawl(Spider, conn=conn)
     process.start()

--- a/collectors/gsk/collector.py
+++ b/collectors/gsk/collector.py
@@ -11,6 +11,6 @@ from .spider import Spider
 # Module API
 
 def collect(conf, conn, date_from=None, date_to=None):
-    process = CrawlerProcess(conf)
+    process = CrawlerProcess(conf['SCRAPY_SETTINGS'])
     process.crawl(Spider, conn=conn, date_from=date_from, date_to=date_to)
     process.start()

--- a/collectors/ictrp/collector.py
+++ b/collectors/ictrp/collector.py
@@ -11,7 +11,7 @@ from .spider import Spider
 # Module API
 
 def collect(conf, conn):
-    process = CrawlerProcess(conf)
+    process = CrawlerProcess(conf['SCRAPY_SETTINGS'])
     process.crawl(Spider, conn=conn,
         http_user=conf['ICTRP_USER'],
         http_pass=conf['ICTRP_PASS'])

--- a/collectors/isrctn/collector.py
+++ b/collectors/isrctn/collector.py
@@ -11,6 +11,6 @@ from .spider import Spider
 # Module API
 
 def collect(conf, conn, date_from=None, date_to=None):
-    process = CrawlerProcess(conf)
+    process = CrawlerProcess(conf['SCRAPY_SETTINGS'])
     process.crawl(Spider, conn=conn, date_from=date_from, date_to=date_to)
     process.start()

--- a/collectors/jprn/collector.py
+++ b/collectors/jprn/collector.py
@@ -11,6 +11,6 @@ from .spider import Spider
 # Module API
 
 def collect(conf, conn, page_from=None, page_to=None):
-    process = CrawlerProcess(conf)
+    process = CrawlerProcess(conf['SCRAPY_SETTINGS'])
     process.crawl(Spider, conn=conn, page_from=page_from, page_to=page_to)
     process.start()

--- a/collectors/nct/parser.py
+++ b/collectors/nct/parser.py
@@ -10,7 +10,6 @@ try:
     from lxml import etree
 except ImportError:
     import xml.etree.ElementTree as etree
-from .. import base
 from .record import Record
 logger = logging.getLogger(__name__)
 
@@ -342,13 +341,10 @@ def _parse_text(res, path):
     """Parsing text from response by path.
     """
     value = None
-    try:
-        node = res.find(path)
-        if node is not None:
-            value = node.text
-            value = value.strip()
-    except Exception:
-        base.config.SENTRY.captureException()
+    node = res.find(path)
+    if node is not None:
+        value = node.text
+        value = value.strip()
     return value
 
 
@@ -356,16 +352,13 @@ def _parse_dict(res, path, expand=None):
     """Parse dict from response by path.
     """
     value = None
-    try:
-        node = res.find(path)
-        if node is not None:
-            text = etree.tostring(node, encoding='utf-8', method='xml')
-            node_dict = xmltodict.parse(text)
-            if expand:
-                node_dict = node_dict[expand]
-            value = node_dict
-    except Exception:
-        base.config.SENTRY.captureException()
+    node = res.find(path)
+    if node is not None:
+        text = etree.tostring(node, encoding='utf-8', method='xml')
+        node_dict = xmltodict.parse(text)
+        if expand:
+            node_dict = node_dict[expand]
+        value = node_dict
     return value
 
 
@@ -373,17 +366,14 @@ def _parse_list(res, path, expand=None):
     """Parse list from response by path.
     """
     value = None
-    try:
-        nodes = res.findall(path)
-        if len(nodes) > 0:
-            hashs = []
-            for node in nodes:
-                text = etree.tostring(node, encoding='utf-8', method='xml')
-                node_dict = xmltodict.parse(text)
-                if expand:
-                    node_dict = node_dict[expand]
-                hashs.append(node_dict)
-            value = hashs
-    except Exception:
-        base.config.SENTRY.captureException()
+    nodes = res.findall(path)
+    if len(nodes) > 0:
+        hashs = []
+        for node in nodes:
+            text = etree.tostring(node, encoding='utf-8', method='xml')
+            node_dict = xmltodict.parse(text)
+            if expand:
+                node_dict = node_dict[expand]
+            hashs.append(node_dict)
+        value = hashs
     return value

--- a/collectors/pfizer/collector.py
+++ b/collectors/pfizer/collector.py
@@ -11,6 +11,6 @@ from .spider import Spider
 # Module API
 
 def collect(conf, conn):
-    process = CrawlerProcess(conf)
+    process = CrawlerProcess(conf['SCRAPY_SETTINGS'])
     process.crawl(Spider, conn=conn)
     process.start()

--- a/collectors/pubmed/collector.py
+++ b/collectors/pubmed/collector.py
@@ -11,6 +11,6 @@ from .spider import Spider
 # Module API
 
 def collect(conf, conn, date_from=None, date_to=None):
-    process = CrawlerProcess(conf)
+    process = CrawlerProcess(conf['SCRAPY_SETTINGS'])
     process.crawl(Spider, conn=conn, date_from=date_from, date_to=date_to)
     process.start()

--- a/collectors/takeda/collector.py
+++ b/collectors/takeda/collector.py
@@ -11,6 +11,6 @@ from .spider import Spider
 # Module API
 
 def collect(conf, conn):
-    process = CrawlerProcess(conf)
+    process = CrawlerProcess(conf['SCRAPY_SETTINGS'])
     process.crawl(Spider, conn=conn)
     process.start()


### PR DESCRIPTION
The issue is that we were passing all constants defined in the
`collectors/base/config.py` file, which now include a Sentry client instance.
Scrapy tries to pickle the settings received and fails, because the Sentry
client instance isn't pickable.

The fix is to move the Scrapy settings to a separate constant and use that
explictly, so we only give Scrapy what is relevant to it.

I also did some adjustements to Sentry, specially for things to fail when an
exception is raised (instead of swallowing it).

Fixes opentrials/opentrials#678