### PR TITLE
Fix migrations to have a single path

### DIFF
--- a/migrations/versions/20170214191843_pubmed_rename_identifiers_list_to_article_ids.py
+++ b/migrations/versions/20170214191843_pubmed_rename_identifiers_list_to_article_ids.py
@@ -9,7 +9,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '3dbb46f23ed7'
-down_revision = u'0087dc1eb534'
+down_revision = u'b32475938a2d'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
As it took us a while to merge some PRs, the migrations ended branching in two
parts. This commit fixes to use a single path. It shouldn't cause any issues, as
we're only messing with the `down` migrations and the migrations aren't
dependent on each other.